### PR TITLE
1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3] 11-08-2024
+
+### Changed
+
+- schema/reactions: 'databaseIds' accepts now arrays of strings (before: a single string, see also v1.1). This allows to e.g. specify multiple MITE cross-references instead of a single one.
+
 ## [1.2] 07-08-2024
 
 ### Changed

--- a/mite_schema/schema/definitions/reactions.json
+++ b/mite_schema/schema/definitions/reactions.json
@@ -34,13 +34,25 @@
       "additionalProperties": false,
       "properties": {
         "rhea": {
-          "$ref": "#/$defs/rhea"
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/rhea"
+          }
         },
         "mite": {
-          "$ref": "#/$defs/mite"
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/mite"
+          }
         },
         "ec": {
-          "$ref": "#/$defs/ec"
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/ec"
+          }
         }
       }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mite_schema"
-version = "1.2"
+version = "1.3"
 description = "Containing the Minimum Information about a Tailoring Enzymes schema and auxiliary methods"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/example_files/example_valid.json
+++ b/tests/example_files/example_valid.json
@@ -68,7 +68,9 @@
                 }
             ],
             "databaseIds": {
-                "mite": "MITE0000000"
+                "mite": ["MITE0000000", "MITE1000000"],
+                "rhea": ["1234", "5678"],
+                "ec": ["EC 1.2.3.4", "EC 1.2"]
             },
             "evidence": [
                 {


### PR DESCRIPTION
## [1.3] 11-08-2024

### Changed

- schema/reactions: 'databaseIds' accepts now arrays of strings (before: a single string, see also v1.1). This allows to e.g. specify multiple MITE cross-references instead of a single one.
