### PR TITLE
Changed changelog min entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.8.1] 29-08-2025
+
+### Changed
+
+- Removed "minItems: 1" from changelog to facilitate data submission via web portal. Change is backwards-compatible.
+
 ## [1.8.0] 17-06-2025
 
 ### Added

--- a/mite_schema/schema/entry.json
+++ b/mite_schema/schema/entry.json
@@ -32,7 +32,6 @@
     "changelog": {
       "title": "Log tracking changes in entry.",
       "type": "array",
-      "minItems": 1,
       "additionalProperties": false,
       "items": {
         "type": "object",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mite_schema"
-version = "1.8.0"
+version = "1.8.1"
 description = "Containing the Minimum Information about a Tailoring Enzymes data standard schema and auxiliary methods"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## [1.8.1] 29-08-2025

### Changed

- Removed "minItems: 1" from changelog to facilitate data submission via web portal. Change is backwards-compatible.

